### PR TITLE
Ensure roundtrip quick test can import local package

### DIFF
--- a/tests/test_roundtrip_quick.py
+++ b/tests/test_roundtrip_quick.py
@@ -1,3 +1,12 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from rtwm.embedder import WatermarkEmbedder
 from rtwm.detector import WatermarkDetector, FRAME_LEN
 


### PR DESCRIPTION
## Summary
- ensure the round-trip smoke test prepends the repository root to sys.path so it can import the local rtwm package when running from source

## Testing
- pytest tests/test_polar.py::test_polar_roundtrip -q

------
https://chatgpt.com/codex/tasks/task_e_68d473d90b288328aef02591e5ad7f2f